### PR TITLE
feat: clear cache while API URL is modified

### DIFF
--- a/src/gitlab.py
+++ b/src/gitlab.py
@@ -39,6 +39,7 @@ def main(wf):
     if args.apiurl:
         log.info("Setting API URL to {url}".format(url=args.apiurl))
         wf.settings['api_url'] = args.apiurl
+        wf.clear_cache()
         return 0
 
     ####################################################################


### PR DESCRIPTION
While we change the API URL, it usually means that we are seeking for a new Gitlab which have new projects. So it's more smooth for us to clear cache while API  URL is modified.